### PR TITLE
Use proper imports

### DIFF
--- a/src/editor/index.html
+++ b/src/editor/index.html
@@ -15,7 +15,6 @@
         </ul>
       </div>
     </div>
-    <script src="resources.js" charset="utf-8"></script>
-    <script src="main.js" charset="utf-8"></script>
+    <script src="main.mjs" charset="utf-8" type="module"></script>
   </body>
 </html>

--- a/src/editor/main.mjs
+++ b/src/editor/main.mjs
@@ -1,6 +1,5 @@
-// TODO: use proper "imports"
 // TODO: typescript
-
+import {resources} from './resources.mjs'
 const canvas = document.getElementById('canvas')
 const ctx = canvas.getContext('2d')
 

--- a/src/editor/resources.mjs
+++ b/src/editor/resources.mjs
@@ -1,5 +1,4 @@
-// TODO: rename to resources.json
-const resources = {
+export const resources = {
   "tiles": [
     "box",
     "boxAlt",


### PR DESCRIPTION
This introduces proper namespacing. The project now haw to run using an HTTP server.

First, install simplehttpserver:

`npm install -g simplehttpserver`

Within the project's root directory, run:

`simplehttpserver`

Then navigate to http://localhost:8000/src/editor